### PR TITLE
Update to the noisetorch org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# pulseaudio [![GoDoc](https://godoc.org/github.com/lawl/pulseaudio?status.svg)](https://godoc.org/github.com/lawl/pulseaudio)
+# pulseaudio [![GoDoc](https://godoc.org/github.com/noisetorch/pulseaudio?status.svg)](https://godoc.org/github.com/noisetorch/pulseaudio)
 Package pulseaudio is a pure-Go (no libpulse) implementation of the PulseAudio native protocol.
 
 Download:
 ```shell
-go get github.com/lawl/pulseaudio
+go get github.com/noisetorch/pulseaudio
 ```
 
 * * *
@@ -12,6 +12,6 @@ Package pulseaudio is a pure-Go (no libpulse) implementation of the PulseAudio n
 This library is a fork of https://github.com/mafik/pulseaudio
 The original library deliberately tries to hide pulseaudio internals and doesn't expose them.
 
-For my usecase I needed the exact opposite, access to pulseaudio internals.
-I will most likely only maintain this as far as is required for [noisetorch](https://github.com/lawl/NoiseTorch) to work.
-Pull Requests are however welcome.
+For the use case of NoiseTorch the opposite is true: access to the pulseaudio internals is needed.
+This will be maintained as is required for [NoiseTorch](https://github.com/noisetorch/NoiseTorch) to work.
+Pull Requests are, however, welcome.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/lawl/pulseaudio
+module github.com/noisetorch/pulseaudio
 
 go 1.14


### PR DESCRIPTION
This update should get us a step closer to https://github.com/noisetorch/NoiseTorch/issues/298.

I'm pretty sure this is all that needs to be done here code/file wise. After this, we should request this be [added to pkg.go.dev](https://pkg.go.dev/about) and then update NoiseTorch to use this instead.